### PR TITLE
Allow for installation of Powercord plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ import { patch, unpatchAll } from '@vizality/patcher';
 import { getModule } from '@vizality/webpack';
 import { ContextMenu } from '@vizality/components';
 
-export default class AddonInstaller extends Plugin { 
+export default class AddonInstaller extends Plugin {
   start () {
     patch(
       'addon-installer',
@@ -13,80 +13,79 @@ export default class AddonInstaller extends Plugin {
       'default',
       (args, res) => {
         const channelID = args[0].channel?.id;
-		if (channelID == '755005584322854972') {
-			if (vizality.manager.plugins.isInstalled('00pccompat') && vizality.manager.plugins.isEnabled('00pccompat')) {
-				const url = args[0].message.content[0].find(e => e);
-				const addonURL = url.rawValue.startswith('<') ? url.rawValue.replace(/<|>/g, '') : url.rawValue;
-				const addonID = addonURL.split('/').pop().toLowerCase();
-				const isPlugin = channelID == '755005584322854972' && true;
-				const addonIsInstalled = vizality.manager[
-					isPlugin == 'plugins'
-				].keys.includes(addonID);
+        if (channelID === '755005584322854972') {
+          if (vizality.manager.plugins.isInstalled('00pccompat') && vizality.manager.plugins.isEnabled('00pccompat')) {
+            const url = args[0].message.content[0].find(e => e);
+            const addonURL = url.rawValue.startswith('<') ? url.rawValue.replace(/<|>/g, '') : url.rawValue;
+            const addonID = addonURL.split('/').pop().toLowerCase();
+            const isPlugin = channelID === '755005584322854972' && true;
+            const addonIsInstalled = vizality.manager[
+              isPlugin === 'plugins'
+            ].keys.includes(addonID);
 
-				if (isPlugin)
-				res.props.children.push(
-					<>
-					<ContextMenu.Separator />
-					<ContextMenu.Group>
-						<ContextMenu.Item
-						label={`${addonIsInstalled ? 'Uninstall' : 'Install'} ${
-							isPlugin == 'Plugin'
-						}`}
-						id="addon-installer"
-						action={async () => {
-							if (addonIsInstalled) {
-								await vizality.manager['plugin'].uninstall(
-									addonID
-								);
-							} else {
-								await vizality.manager['plugin'].install(addonURL);
-							}
-						}}
-						/>
-					</ContextMenu.Group>
-					</>
-				)
-			}
-		} else {
-        const isPlugin = channelID === '753291447523868753' && true;
+            if (isPlugin) {
+              res.props.children.push(
+                <>
+                  <ContextMenu.Separator />
+                  <ContextMenu.Group>
+                    <ContextMenu.Item
+                      label={`${addonIsInstalled ? 'Uninstall' : 'Install'} ${isPlugin === 'Plugin'
+                      }`}
+                      id="addon-installer"
+                      action={async () => {
+                        if (addonIsInstalled) {
+                          await vizality.manager.plugin.uninstall(
+                            addonID
+                          );
+                        } else {
+                          await vizality.manager.plugin.install(addonURL);
+                        }
+                      }}
+                    />
+                  </ContextMenu.Group>
+                </>
+              );
+            }
+          }
+        } else {
+          const isPlugin = channelID === '753291447523868753' && true;
 
-        if (isPlugin || channelID === '753291485100769411') {
-          const addonURL = args[0].message?.embeds[0]?.fields[0].rawValue;
-          const addonID = addonURL.split('/').pop().toLowerCase();
+          if (isPlugin || channelID === '753291485100769411') {
+            const addonURL = args[0].message?.embeds[0]?.fields[0].rawValue;
+            const addonID = addonURL.split('/').pop().toLowerCase();
 
-          const pluginsOrThemes = isPlugin ? 'plugins' : 'themes';
+            const pluginsOrThemes = isPlugin ? 'plugins' : 'themes';
 
-          const addonIsInstalled = vizality.manager[
-            pluginsOrThemes
-          ].keys.includes(addonID);
+            const addonIsInstalled = vizality.manager[
+              pluginsOrThemes
+            ].keys.includes(addonID);
 
-          res.props.children.push(
-            <>
-              <ContextMenu.Separator />
-              <ContextMenu.Group>
-                <ContextMenu.Item
-                  label={`${addonIsInstalled ? 'Uninstall' : 'Install'} ${
-                    isPlugin ? 'Plugin' : 'Theme'
-                  }`}
-                  id="addon-installer"
-                  action={async () => {
-                    if (addonIsInstalled) {
-                      await vizality.manager[pluginsOrThemes].uninstall(
-                        addonID
-                      );
-                    } else {
-                      await vizality.manager[pluginsOrThemes].install(addonURL);
-                    }
-                  }}
-                />
-              </ContextMenu.Group>
-            </>
-          );
+            res.props.children.push(
+              <>
+                <ContextMenu.Separator />
+                <ContextMenu.Group>
+                  <ContextMenu.Item
+                    label={`${addonIsInstalled ? 'Uninstall' : 'Install'} ${isPlugin ? 'Plugin' : 'Theme'
+                    }`}
+                    id="addon-installer"
+                    action={async () => {
+                      if (addonIsInstalled) {
+                        await vizality.manager[pluginsOrThemes].uninstall(
+                          addonID
+                        );
+                      } else {
+                        await vizality.manager[pluginsOrThemes].install(addonURL);
+                      }
+                    }}
+                  />
+                </ContextMenu.Group>
+              </>
+            );
+          }
+
+          return res;
         }
-
-        return res;
-      }
-	  });
+      });
   }
 
   stop () {

--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ export default class AddonInstaller extends Plugin {
         const channelID = args[0].channel?.id;
         if (channelID === '755005584322854972') {
           if (vizality.manager.plugins.isInstalled('00pccompat') && vizality.manager.plugins.isEnabled('00pccompat')) {
-            const addonURL = args[0].href.match(/^https?:\/\/(www.)?git(hub|lab).com\/[\w-]+\/[\w-]+\/?/);
+            // eslint-disable-next-line no-useless-escape
+            const addonURL = args[0].href.match(/(http|https)\:\/\/github\.com\/(.+)\/(.*?)\.git/);
             const addonID = addonURL.split('/').pop().toLowerCase();
             const isPlugin = channelID === '755005584322854972' && true;
             const addonIsInstalled = vizality.manager[

--- a/index.js
+++ b/index.js
@@ -9,14 +9,13 @@ export default class AddonInstaller extends Plugin {
   start () {
     patch(
       'addon-installer',
-      getModule((m) => m.default?.displayName === 'MessageContextMenu'),
+      getModule((m) => m.default && m.default?.displayName === 'MessageContextMenu'),
       'default',
       (args, res) => {
         const channelID = args[0].channel?.id;
         if (channelID === '755005584322854972') {
           if (vizality.manager.plugins.isInstalled('00pccompat') && vizality.manager.plugins.isEnabled('00pccompat')) {
-            const url = args[0].message.content[0].find(e => e);
-            const addonURL = url.rawValue.startswith('<') ? url.rawValue.replace(/<|>/g, '') : url.rawValue;
+            const addonURL = args[0].href.match(/^https?:\/\/(www.)?git(hub|lab).com\/[\w-]+\/[\w-]+\/?/);
             const addonID = addonURL.split('/').pop().toLowerCase();
             const isPlugin = channelID === '755005584322854972' && true;
             const addonIsInstalled = vizality.manager[

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ import { patch, unpatchAll } from '@vizality/patcher';
 import { getModule } from '@vizality/webpack';
 import { ContextMenu } from '@vizality/components';
 
-const githubRegex = /https?:\/\/github\.com\/[a-zA-Z0-9-]+\/[a-zA-Z0-9-]+\/?$/m;
+const githubRegex = /https?:\/\/github\.com\/[a-zA-Z0-9-]+\/[a-zA-Z0-9-]+\/?/m;
 
 export default class AddonInstaller extends Plugin {
   start () {

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ export default class AddonInstaller extends Plugin {
   start () {
     patch(
       'addon-installer',
-      getModule((m) => m.default && m.default?.displayName === 'MessageContextMenu'),
+      getModule((m) => m.default?.displayName === 'MessageContextMenu'),
       'default',
       (args, res) => {
         const channelID = args[0].channel?.id;

--- a/index.js
+++ b/index.js
@@ -15,14 +15,10 @@ export default class AddonInstaller extends Plugin {
         const channelID = args[0].channel?.id;
         if (channelID === '755005584322854972') {
           if (vizality.manager.plugins.isInstalled('00pccompat') && vizality.manager.plugins.isEnabled('00pccompat')) {
-            // eslint-disable-next-line no-useless-escape
-            const githubRegex = /(http|https)\:\/\/github\.com\/(.+)\/(.*?)\.git/;
-            const addonURL = args[0].href?.match(githubRegex);
+            const addonURL = args[0].message?.embeds[0].url;
             const addonID = addonURL.split('/').pop().toLowerCase();
             const isPlugin = channelID === '755005584322854972' && true;
-            const addonIsInstalled = vizality.manager[
-              isPlugin === 'plugins'
-            ].keys.includes(addonID);
+            const addonIsInstalled = vizality.manager.plugins.keys.includes(addonID);
 
             if (isPlugin) {
               res.props.children.push(

--- a/index.js
+++ b/index.js
@@ -16,7 +16,8 @@ export default class AddonInstaller extends Plugin {
         if (channelID === '755005584322854972') {
           if (vizality.manager.plugins.isInstalled('00pccompat') && vizality.manager.plugins.isEnabled('00pccompat')) {
             // eslint-disable-next-line no-useless-escape
-            const addonURL = args[0].href.match(/(http|https)\:\/\/github\.com\/(.+)\/(.*?)\.git/);
+            const githubRegex = /(http|https)\:\/\/github\.com\/(.+)\/(.*?)\.git/;
+            const addonURL = args[0].href?.match(githubRegex);
             const addonID = addonURL.split('/').pop().toLowerCase();
             const isPlugin = channelID === '755005584322854972' && true;
             const addonIsInstalled = vizality.manager[

--- a/index.js
+++ b/index.js
@@ -13,6 +13,41 @@ export default class AddonInstaller extends Plugin {
       'default',
       (args, res) => {
         const channelID = args[0].channel?.id;
+		if (channelID == '755005584322854972') {
+			if (vizality.manager.plugins.isInstalled('00pccompat') && vizality.manager.plugins.isEnabled('00pccompat')) {
+				const url = args[0].message.content[0].find(e => e);
+				const addonURL = url.rawValue.startswith('<') ? url.rawValue.replace(/<|>/g, '') : url.rawValue;
+				const addonID = addonURL.split('/').pop().toLowerCase();
+				const isPlugin = channelID == '755005584322854972' && true;
+				const addonIsInstalled = vizality.manager[
+					isPlugin == 'plugins'
+				].keys.includes(addonID);
+
+				if (isPlugin)
+				res.props.children.push(
+					<>
+					<ContextMenu.Separator />
+					<ContextMenu.Group>
+						<ContextMenu.Item
+						label={`${addonIsInstalled ? 'Uninstall' : 'Install'} ${
+							isPlugin == 'Plugin'
+						}`}
+						id="addon-installer"
+						action={async () => {
+							if (addonIsInstalled) {
+								await vizality.manager['plugin'].uninstall(
+									addonID
+								);
+							} else {
+								await vizality.manager['plugin'].install(addonURL);
+							}
+						}}
+						/>
+					</ContextMenu.Group>
+					</>
+				)
+			}
+		} else {
         const isPlugin = channelID === '753291447523868753' && true;
 
         if (isPlugin || channelID === '753291485100769411') {
@@ -51,7 +86,7 @@ export default class AddonInstaller extends Plugin {
 
         return res;
       }
-    );
+	  });
   }
 
   stop () {

--- a/index.js
+++ b/index.js
@@ -16,35 +16,31 @@ export default class AddonInstaller extends Plugin {
       (args, res) => {
         const channelID = args[0].channel?.id;
         if (channelID === '755005584322854972') {
-          if (vizality.manager.plugins.isInstalled('00pccompat') && vizality.manager.plugins.isEnabled('00pccompat')) {
+          if (vizality.manager.plugins.isEnabled('00pccompat')) {
             const addonURL = args[0].message?.content.match(githubRegex)[0];
             const addonID = addonURL.split('/').pop().toLowerCase();
-            const isPlugin = channelID === '755005584322854972' && true;
             const addonIsInstalled = vizality.manager.plugins.keys.includes(addonID);
-
-            if (isPlugin) {
-              res.props.children.push(
-                <>
-                  <ContextMenu.Separator />
-                  <ContextMenu.Group>
-                    <ContextMenu.Item
-                      label={`${addonIsInstalled ? 'Uninstall' : 'Install'} ${'Plugin'
-                      }`}
-                      id="addon-installer"
-                      action={async () => {
-                        if (addonIsInstalled) {
-                          await vizality.manager.plugins.uninstall(
-                            addonID
-                          );
-                        } else {
-                          await vizality.manager.plugins.install(addonURL);
-                        }
-                      }}
-                    />
-                  </ContextMenu.Group>
-                </>
-              );
-            }
+            res.props.children.push(
+              <>
+                <ContextMenu.Separator />
+                <ContextMenu.Group>
+                  <ContextMenu.Item
+                    label={`${addonIsInstalled ? 'Uninstall' : 'Install'} ${'Plugin'
+                    }`}
+                    id="addon-installer"
+                    action={async () => {
+                      if (addonIsInstalled) {
+                        await vizality.manager.plugins.uninstall(
+                          addonID
+                        );
+                      } else {
+                        await vizality.manager.plugins.install(addonURL);
+                      }
+                    }}
+                  />
+                </ContextMenu.Group>
+              </>
+            );
           }
         } else {
           const isPlugin = channelID === '753291447523868753' && true;

--- a/index.js
+++ b/index.js
@@ -26,16 +26,16 @@ export default class AddonInstaller extends Plugin {
                   <ContextMenu.Separator />
                   <ContextMenu.Group>
                     <ContextMenu.Item
-                      label={`${addonIsInstalled ? 'Uninstall' : 'Install'} ${isPlugin === 'Plugin'
+                      label={`${addonIsInstalled ? 'Uninstall' : 'Install'} ${'Plugin'
                       }`}
                       id="addon-installer"
                       action={async () => {
                         if (addonIsInstalled) {
-                          await vizality.manager.plugin.uninstall(
+                          await vizality.manager.plugins.uninstall(
                             addonID
                           );
                         } else {
-                          await vizality.manager.plugin.install(addonURL);
+                          await vizality.manager.plugins.install(addonURL);
                         }
                       }}
                     />

--- a/index.js
+++ b/index.js
@@ -12,44 +12,77 @@ export default class AddonInstaller extends Plugin {
 			getModule((m) => m.default?.displayName === "MessageContextMenu"),
 			"default",
 			(args, res) => {
-				const addonURL = args[0].message.embeds[0].fields[0].rawValue;
-				const addonID = addonURL.split("/").pop().toLowerCase();
+				let channelID = args[0].channel?.id;
+				if (channelID == "755005584322854972") {
+					if (vizality.manager.plugins.isInstalled('00pccompat') && vizality.manager.plugins.isEnabled('00pccompat')) {
+						const URL = message.content[0].find(e => e);
+						const addonURL = URL.rawValue.startsWith('<') ? URL.rawValue.replace(/<|>/g, '') : URL.rawValue;
+						const addonID = addonURL.split('/').pop().toLowerCase();
+						const isPlugin = channelID == "755005584322854972" && true;
+						const addonIsInstalled = vizality.manager[
+							isPlugin == "plugins"
+						].keys.includes(addonID);
 
-				const channelID = args[0].channel?.id;
-				const isPlugin = channelID == "753291447523868753" && true;
-				const pluginsOrThemes = isPlugin ? "plugins" : "themes";
+						if (isPlugin)
+							res.props.children.push(
+								<>
+									<ContextMenu.Separator />
+									<ContextMenu.Group>
+										<ContextMenu.Item
+											label={`${addonIsInstalled ? "Uninstall" : "Install"} ${isPlugin == "Plugin"
+												}`}
+											id="addon-installer"
+											action={async () => {
+												if (addonIsInstalled) {
+													await vizality.manager["Plugin"].uninstall(
+														addonID
+													);
+												} else {
+													await vizality.manager["Plugin"].install(addonURL);
+												}
+											}}
+										/>
+									</ContextMenu.Group>
+								</>
+							)
+					};
+				} else {
+					const addonURL = args[0].message.embeds[0].fields[0].rawValue;
+					const addonID = addonURL.split("/").pop().toLowerCase();
 
-				const addonIsInstalled = vizality.manager[
-					pluginsOrThemes
-				].keys.includes(addonID);
+					const isPlugin = channelID == "753291447523868753" && true;
+					const pluginsOrThemes = isPlugin ? "plugins" : "themes";
 
-				if (isPlugin || channelID == "753291485100769411")
-					res.props.children.push(
-						<>
-							<ContextMenu.Separator />
-							<ContextMenu.Group>
-								<ContextMenu.Item
-									label={`${addonIsInstalled ? "Uninstall" : "Install"} ${
-										isPlugin ? "Plugin" : "Theme"
-									}`}
-									id="addon-installer"
-									action={async () => {
-										if (addonIsInstalled) {
-											await vizality.manager[pluginsOrThemes].uninstall(
-												addonID
-											);
-										} else {
-											await vizality.manager[pluginsOrThemes].install(addonURL);
-										}
-									}}
-								/>
-							</ContextMenu.Group>
-						</>
-					);
+					const addonIsInstalled = vizality.manager[
+						pluginsOrThemes
+					].keys.includes(addonID);
 
-				return res;
-			}
-		);
+					if (isPlugin || channelID == "753291485100769411")
+						res.props.children.push(
+							<>
+								<ContextMenu.Separator />
+								<ContextMenu.Group>
+									<ContextMenu.Item
+										label={`${addonIsInstalled ? "Uninstall" : "Install"} ${isPlugin ? "Plugin" : "Theme"
+											}`}
+										id="addon-installer"
+										action={async () => {
+											if (addonIsInstalled) {
+												await vizality.manager[pluginsOrThemes].uninstall(
+													addonID
+												);
+											} else {
+												await vizality.manager[pluginsOrThemes].install(addonURL);
+											}
+										}}
+									/>
+								</ContextMenu.Group>
+							</>
+						);
+
+					return res;
+				};
+			});
 	}
 
 	stop() {

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ import { patch, unpatchAll } from '@vizality/patcher';
 import { getModule } from '@vizality/webpack';
 import { ContextMenu } from '@vizality/components';
 
-const githubRegex = /https?:\/\/github\.com\/[a-zA-Z0-9-]+\/[a-zA-Z0-9-]+\/?$/;
+const githubRegex = /https?:\/\/github\.com\/[a-zA-Z0-9-]+\/[a-zA-Z0-9-]+\/?$/m;
 
 export default class AddonInstaller extends Plugin {
   start () {
@@ -16,9 +16,8 @@ export default class AddonInstaller extends Plugin {
       (args, res) => {
         const channelID = args[0].channel?.id;
         if (channelID === '755005584322854972') {
-          console.log(args[0].message?.content.match(githubRegex));
           if (vizality.manager.plugins.isInstalled('00pccompat') && vizality.manager.plugins.isEnabled('00pccompat')) {
-            const addonURL = args[0].message?.embeds[0]?.url || args[0].message?.content.match(githubRegex)[0];
+            const addonURL = args[0].message?.content.match(githubRegex)[0];
             const addonID = addonURL.split('/').pop().toLowerCase();
             const isPlugin = channelID === '755005584322854972' && true;
             const addonIsInstalled = vizality.manager.plugins.keys.includes(addonID);

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ import { patch, unpatchAll } from '@vizality/patcher';
 import { getModule } from '@vizality/webpack';
 import { ContextMenu } from '@vizality/components';
 
+const githubRegex = /https?:\/\/github\.com\/[a-zA-Z0-9-]+\/[a-zA-Z0-9-]+\/?$/;
+
 export default class AddonInstaller extends Plugin {
   start () {
     patch(
@@ -14,8 +16,9 @@ export default class AddonInstaller extends Plugin {
       (args, res) => {
         const channelID = args[0].channel?.id;
         if (channelID === '755005584322854972') {
+          console.log(args[0].message?.content.match(githubRegex));
           if (vizality.manager.plugins.isInstalled('00pccompat') && vizality.manager.plugins.isEnabled('00pccompat')) {
-            const addonURL = args[0].message?.embeds[0].url;
+            const addonURL = args[0].message?.embeds[0]?.url || args[0].message?.content.match(githubRegex)[0];
             const addonID = addonURL.split('/').pop().toLowerCase();
             const isPlugin = channelID === '755005584322854972' && true;
             const addonIsInstalled = vizality.manager.plugins.keys.includes(addonID);

--- a/index.js
+++ b/index.js
@@ -5,8 +5,6 @@ import { patch, unpatchAll } from '@vizality/patcher';
 import { getModule } from '@vizality/webpack';
 import { ContextMenu } from '@vizality/components';
 
-const githubRegex = /https?:\/\/github\.com\/[a-zA-Z0-9-]+\/[a-zA-Z0-9-]+\/?/m;
-
 export default class AddonInstaller extends Plugin {
   start () {
     patch(
@@ -17,7 +15,7 @@ export default class AddonInstaller extends Plugin {
         const channelID = args[0].channel?.id;
         if (channelID === '755005584322854972') {
           if (vizality.manager.plugins.isEnabled('00pccompat')) {
-            const addonURL = args[0].message?.content.match(githubRegex)[0];
+            const addonURL = args[0].message?.content.match(/https?:\/\/github\.com\/[a-zA-Z0-9-]+\/[a-zA-Z0-9-]+\/?/m)[0];
             const addonID = addonURL.split('/').pop().toLowerCase();
             const addonIsInstalled = vizality.manager.plugins.keys.includes(addonID);
             res.props.children.push(


### PR DESCRIPTION
This pull request adds the ability for addon installer to install powercord plugins only under 2 conditions:
1. The user is currently in the plugin-links channel of powercord's server
2. The user has [pccompat](https://github.com/MoltenCoreDev/pcCompat) ~both installed and~ enabled


~It works perfectly but 2 problems remain~


~1. If the plugin entry has multiple links, then it cannot install the powercord plugin even when the user press the "Install Plugin" button (no errors are thrown)~
~2. If the plugin developer removed the embed of their plugin link in their entry, then an error is thrown in devtools console~


~I am certain these 2 problems could both be soon fixed but for as long as I have been working on this, I'm glad that the essentials functions work~
All fixed as per cb146403589907f511c3a76f454f751254348ef5 and dfcf88360c162caccf6fd01b8b9516e6780c3e79, thanks to @LavaSquids for providing a working regex!
Feel free to review this pull request!